### PR TITLE
Add permissions to publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Publish flow needs specific permissions to use `--provenance`.